### PR TITLE
Use Python 3.6.0b3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   pre:
     - cd /opt/circleci/.pyenv && git pull && cd -
   python:
-    version: 3.6.0b2
+    version: 3.6.0b3
 dependencies:
   pre:
     - pip install -U setuptools pip wheel


### PR DESCRIPTION
python-build in pyenv does not support Python 3.6.0b3 yet :-1:
https://github.com/yyuu/pyenv/tree/master/plugins/python-build/share/python-build

We should wait...