### PR TITLE
Docker イメージのサイズを削減

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-slim
 MAINTAINER Yusuke Miyazaki <miyazaki.dev@gmail.com>
 
 RUN mkdir -p /app/


### PR DESCRIPTION
Use python:3.6-slim instead of python-3.6 as a base image.