### PR TITLE
Bump bootstrap from 3.x to 4.x

### DIFF
--- a/data/entries.yml
+++ b/data/entries.yml
@@ -615,7 +615,7 @@
 
 - date: 2018-12-18
   author: ぷらす
-  title: 人の顔を絵文字 &#x1f607; に変換するWebサービスをAmazon Rekognition x Serverlessで開発して、デプロイをCIで自動化した話
+  title: WebサービスをAmazon Rekognition x Serverlessで開発してみた
   url: https://qiita.com/plus_kyoto/items/fa0215cee44251bf2e50
 
 - date: 2018-12-19

--- a/source/base.css
+++ b/source/base.css
@@ -1,7 +1,8 @@
 @font-face {
   font-family: CustomYuGothic;
   font-weight: normal;
-  src: local("YuGothic-Medium"), local("Yu Gothic Medium"), local("YuGothic-Regular");
+  src: local("YuGothic-Medium"), local("Yu Gothic Medium"),
+    local("YuGothic-Regular");
 }
 
 @font-face {
@@ -11,10 +12,17 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN", CustomYuGothic, Meiryo, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", CustomYuGothic, Meiryo, sans-serif;
   font-feature-settings: "palt";
 }
 
-.schedule{
+.schedule {
   white-space: nowrap;
+  font-size: 14px;
+}
+
+.table td,
+.table th {
+  padding: 0.5rem;
 }

--- a/source/base.css
+++ b/source/base.css
@@ -14,3 +14,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN", CustomYuGothic, Meiryo, sans-serif;
   font-feature-settings: "palt";
 }
+
+.schedule{
+  white-space: nowrap;
+}

--- a/source/index.html
+++ b/source/index.html
@@ -1,205 +1,292 @@
 <!DOCTYPE html>
 <html lang="ja">
-    <head prefix="og: http://ogp.me/ns#">
-        <meta charset="utf-8">
-        <title>{{ title }}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="keywords" content="Advent,Calendar,アドベントカレンダー,CAMPHOR-,京都,学生,IT">
-        <meta name="description" content="京都の学生コミュニティ CAMPHOR- の Advent Calendar 特設ページです。様々な記事を毎日追加していきます。">
-        <meta property="og:type" content="website">
-        <meta property="og:title" content="{{ title }}">
-        <meta property="og:site_name" content="{{ title }}">
-        <meta property="og:description" content="{{ description }}">
-        <meta property="og:url" content="{{ root }}">
-        <meta property="og:image" content="{{ root }}logo_ogp_3.png">
-        <meta property="og:locale" content="ja_JP">
-        <meta name="twitter:card" content="summary">
-        <meta name="twitter:site" content="@CamphorKyoto">
-        <meta name="twitter:title" content="{{ title }}">
-        <meta name="twitter:description" content="{{ description }}">
-        <meta name="twitter:image" content="{{ root }}logo_twitter_2.png">
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-        crossorigin="anonymous">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
-        crossorigin="anonymous">
-        <link rel="amphtml" href="{{ root }}amp.html">
-        <style>
-            {% include "base.css" %}
+  <head prefix="og: http://ogp.me/ns#">
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="keywords"
+      content="Advent,Calendar,アドベントカレンダー,CAMPHOR-,京都,学生,IT"
+    />
+    <meta
+      name="description"
+      content="京都の学生コミュニティ CAMPHOR- の Advent Calendar 特設ページです。様々な記事を毎日追加していきます。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{ title }}" />
+    <meta property="og:site_name" content="{{ title }}" />
+    <meta property="og:description" content="{{ description }}" />
+    <meta property="og:url" content="{{ root }}" />
+    <meta property="og:image" content="{{ root }}logo_ogp_3.png" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@CamphorKyoto" />
+    <meta name="twitter:title" content="{{ title }}" />
+    <meta name="twitter:description" content="{{ description }}" />
+    <meta name="twitter:image" content="{{ root }}logo_twitter_2.png" />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
+      crossorigin="anonymous"
+    />
+    <link rel="amphtml" href="{{ root }}amp.html" />
+    <style>
+      {% include "base.css" %}
 
-            .jumbotron h1 {
-                font-size: 48px;
-            }
+      .jumbotron h1 {
+          font-size: 48px;
+      }
 
-            @media (max-width: 768px) {
-                .jumbotron h1 {
-                    font-size: 32px;
-                }
-            }
+      @media (max-width: 768px) {
+          .jumbotron h1 {
+              font-size: 32px;
+          }
+      }
 
-            @media (max-width: 320px) {
-                .jumbotron h1 {
-                    font-size: 25px;
-                }
-            }
+      @media (max-width: 320px) {
+          .jumbotron h1 {
+              font-size: 25px;
+          }
+      }
 
-            .social-buttons {
-                position: fixed;
-                bottom: 20px;
-                right: 20px;
-            }
+      .social-buttons {
+          position: fixed;
+          bottom: 20px;
+          right: 20px;
+      }
 
-            .social-buttons a {
-                display: inline-block;
-                margin: 0 4px;
-                border-radius: 25px;
-                border-width: 0;
-                padding: 0;
-                width: 50px;
-                height: 50px;
-                line-height: 50px;
-                font-size: 25px;
-                color: white;
-            }
+      .social-buttons a {
+          display: inline-block;
+          margin: 0 4px;
+          border-radius: 25px;
+          border-width: 0;
+          padding: 0;
+          width: 50px;
+          height: 50px;
+          line-height: 50px;
+          font-size: 25px;
+          color: white;
+      }
 
-            .social-buttons a:focus,
-            .social-buttons a:hover {
-                color: white;
-            }
+      .social-buttons a:focus,
+      .social-buttons a:hover {
+          color: white;
+      }
 
-            .social-buttons a.twitter {
-                background-color: #55acee;
-            }
+      .social-buttons a.twitter {
+          background-color: #55acee;
+      }
 
-            .social-buttons a.twitter:focus, 
-            .social-buttons a.twitter:hover {
-                background-color: #4790c7;
-            }
+      .social-buttons a.twitter:focus,
+      .social-buttons a.twitter:hover {
+          background-color: #4790c7;
+      }
 
-            .social-buttons a.facebook {
-                background-color: #3b5998;
-            }
+      .social-buttons a.facebook {
+          background-color: #3b5998;
+      }
 
-            .social-buttons a.facebook:focus, 
-            .social-buttons a.facebook:hover {
-                background-color: #2D4373;
-            }
-        </style>
-    </head>
-    <body>
-        <nav class="navbar navbar-light bg-light navbar-expand-md">
-                <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbar-collapse"> 
-                  <span class="sr-only">Toggle navigation</span>
-                  &#x2630;
-                </button>
-                <a class="navbar-brand" href="#">CAMPHOR- Advent Calendar</a>
-                <div class="collapse navbar-collapse" id="navbar-collapse">
-                    <ul class="nav navbar-nav ml-auto">
-                        <li class="nav-item"><a href="https://blog.camph.net" target="_blank" class="nav-link">Blog</a></li>
-                        <li class="nav-item"><a href="https://tech.camph.net" target="_blank" class="nav-link">Tech Blog</a></li>
-                        <li class="nav-item"><a href="https://twitter.com/CamphorKyoto" target="_blank" class="nav-link">Twitter</a></li>
-                        <li class="nav-item"><a href="https://www.facebook.com/Camphorcamphor/" target="_blank" class="nav-link">Facebook</a></li>
-                        <li class="nav-item"><a href="https://camph.net" target="_blank" class="nav-link">Website</a></li>
-                    </ul>
-                </div>
-        </nav>
-        <div class="jumbotron">
-            <div class="container">
-                <div class="row">
-                    <div class="col-md-12 offset-md-2 col-lg-8 text-center">
-                         <h1>
-              <img class="img-fluid" src="./header.svg" alt="CAMPHOR- Advent Calendar">
+      .social-buttons a.facebook:focus,
+      .social-buttons a.facebook:hover {
+          background-color: #2D4373;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar navbar-light bg-light navbar-expand-md">
+      <button
+        type="button"
+        class="navbar-toggler collapsed"
+        data-toggle="collapse"
+        data-target="#navbar-collapse"
+      >
+        <span class="sr-only">Toggle navigation</span>
+        &#x2630;
+      </button>
+      <a class="navbar-brand" href="#">CAMPHOR- Advent Calendar</a>
+      <div class="collapse navbar-collapse" id="navbar-collapse">
+        <ul class="nav navbar-nav ml-auto">
+          <li class="nav-item">
+            <a href="https://blog.camph.net" target="_blank" class="nav-link"
+              >Blog</a
+            >
+          </li>
+          <li class="nav-item">
+            <a href="https://tech.camph.net" target="_blank" class="nav-link"
+              >Tech Blog</a
+            >
+          </li>
+          <li class="nav-item">
+            <a
+              href="https://twitter.com/CamphorKyoto"
+              target="_blank"
+              class="nav-link"
+              >Twitter</a
+            >
+          </li>
+          <li class="nav-item">
+            <a
+              href="https://www.facebook.com/Camphorcamphor/"
+              target="_blank"
+              class="nav-link"
+              >Facebook</a
+            >
+          </li>
+          <li class="nav-item">
+            <a href="https://camph.net" target="_blank" class="nav-link"
+              >Website</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <div class="jumbotron">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12 offset-md-2 col-lg-8 text-center">
+            <h1>
+              <img
+                class="img-fluid"
+                src="./header.svg"
+                alt="CAMPHOR- Advent Calendar"
+              />
             </h1>
             <p class="lead">
               CAMPHOR- のメンバーとOB・OGが様々なトピックをお届けします!
-            </p>     
-              </div>
-            </div>
-        </div>
-        </div>
-        <div class="container">
-            <div class="row">
-              {% for year, entries in entries_for_years.items() %}
-                <div class="col-12">
-                     <h2>{{ year }}</h2>
-                    <div class="table-responsive">
-                        <table class="table table-striped schedule">
-                            <tr><th>日</th><th>担当</th><th>タイトル</th><th class="text-right">はてブ</th></tr>
-                            {% for entry in entries %}                            
-                            <tr>
-                                <td>{{ entry.date.month }}/{{ entry.date.day }}</td>
-                                <td>
-                                  {% if entry.author %}
-                                    {% if entry.author_url %}
-                                      <a href="{{ entry.author_url }}" target="_blank">{{ entry.author }}</a>
-                                      {% else %} 
-                                        {{ entry.author }}
-                                      {% endif %} 
-                                    {% else %}
-                                     未定 
-                                    {% endif %}
-                                  </td>
-                                <td>
-                                  {% if entry.title %} 
-                                    {% if entry.url %} 
-                                    <a href="{{ entry.url }}" target="_blank">{{ entry.title }}</a>
-                                    {% else %}
-                                      {{ entry.title }}
-                                      {% endif %} 
-                                      {% else %}
-                                      未定
-                                        {% endif %}
-                                      </td>
-                                <td class="text-right">
-                                  {% if entry.url %}
-                                   <a href="http://b.hatena.ne.jp/entry/{{ entry.url }}" class="hateb-link" data-url="{{ entry.url }}" target="_blank">Loading</a>
-                                    {% else %} 
-                                    - 
-                                    {% endif %}
-                                  </td>
-                            </tr>
-                            {% endfor %}
-                          </table>
-                    </div>
-                </div>
-                {% endfor %}
-              </div>
-        </div>
-        <footer class="text-center">
-            <hr>
-            <p>
-              Copyright &copy; 2014-2018, CAMPHOR-.
             </p>
-        </footer>
-        <div class="social-buttons">
-          <a class="btn twitter" href="https://twitter.com/intent/tweet?text=CAMPHOR%2D%20Advent%20Calendar&url=https%3A%2F%2Fadvent.camph.net%2F&via=CamphorKyoto&related=CamphorKyoto" target="_blank">
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <div class="row">
+        {% for year, entries in entries_for_years.items() %}
+        <div class="col-12">
+          <h2>{{ year }}</h2>
+          <div class="table-responsive">
+            <table class="table table-striped schedule">
+              <tr>
+                <th>日</th>
+                <th>担当</th>
+                <th>タイトル</th>
+                <th class="text-right">はてブ</th>
+              </tr>
+              {% for entry in entries %}
+              <tr>
+                <td>{{ entry.date.month }}/{{ entry.date.day }}</td>
+                <td>
+                  {% if entry.author %} {% if entry.author_url %}
+                  <a href="{{ entry.author_url }}" target="_blank">{{
+                    entry.author
+                  }}</a>
+                  {% else %}
+                  {{ entry.author }}
+                  {% endif %} {% else %} 未定 {% endif %}
+                </td>
+                <td>
+                  {% if entry.title %} {% if entry.url %}
+                  <a href="{{ entry.url }}" target="_blank">{{
+                    entry.title
+                  }}</a>
+                  {% else %}
+                  {{ entry.title }}
+                  {% endif %} {% else %} 未定 {% endif %}
+                </td>
+                <td class="text-right">
+                  {% if entry.url %}
+                  <a
+                    href="http://b.hatena.ne.jp/entry/{{ entry.url }}"
+                    class="hateb-link"
+                    data-url="{{ entry.url }}"
+                    target="_blank"
+                    >Loading</a
+                  >
+                  {% else %} - {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </table>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    <footer class="text-center">
+      <hr />
+      <p>
+        Copyright &copy; 2014-2018, CAMPHOR-.
+      </p>
+    </footer>
+    <div class="social-buttons">
+      <a
+        class="btn twitter"
+        href="https://twitter.com/intent/tweet?text=CAMPHOR%2D%20Advent%20Calendar&url=https%3A%2F%2Fadvent.camph.net%2F&via=CamphorKyoto&related=CamphorKyoto"
+        target="_blank"
+      >
         <i class="fa fa-twitter" aria-hidden="true"></i>
       </a>
- <a class="btn facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fadvent.camph.net%2F" target="_blank">
+      <a
+        class="btn facebook"
+        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fadvent.camph.net%2F"
+        target="_blank"
+      >
         <i class="fa fa-facebook" aria-hidden="true"></i>
       </a>
-        </div>
-        <script type="application/ld+json">
-          {
-            "@context": "http://schema.org",
-            "@type": "WebSite",
-            "name": "CAMPHOR- Advent Calendar",
-            "url": "https://advent.camph.net/"
-          }
-        </script>
-        <script src="https://code.jquery.com/jquery-3.3.1.min.js"  crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-        <script src="./index.js"></script>
-        {% if not debug %}
-        <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            ga('create', 'UA-36244002-7', 'auto');
-            ga('send', 'pageview');
-          </script>
-         {% endif %}
-        </body>
+    </div>
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "WebSite",
+        "name": "CAMPHOR- Advent Calendar",
+        "url": "https://advent.camph.net/"
+      }
+    </script>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+      crossorigin="anonymous"
+    ></script>
+    <script src="./index.js"></script>
+    {% if not debug %}
+    <script>
+      (function(i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function() {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "//www.google-analytics.com/analytics.js",
+        "ga"
+      );
+      ga("create", "UA-36244002-7", "auto");
+      ga("send", "pageview");
+    </script>
+    {% endif %}
+  </body>
 </html>

--- a/source/index.html
+++ b/source/index.html
@@ -250,6 +250,7 @@
     </script>
     <script
       src="https://code.jquery.com/jquery-3.3.1.min.js"
+      integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
       crossorigin="anonymous"
     ></script>
     <script

--- a/source/index.html
+++ b/source/index.html
@@ -1,207 +1,205 @@
 <!DOCTYPE html>
 <html lang="ja">
-  <head prefix="og: http://ogp.me/ns#">
-    <meta charset="utf-8">
-    <title>{{ title }}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="keywords" content="Advent,Calendar,アドベントカレンダー,CAMPHOR-,京都,学生,IT">
-    <meta name="description" content="京都の学生コミュニティ CAMPHOR- の Advent Calendar 特設ページです。様々な記事を毎日追加していきます。">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="{{ title }}">
-    <meta property="og:site_name" content="{{ title }}">
-    <meta property="og:description" content="{{ description }}">
-    <meta property="og:url" content="{{ root }}">
-    <meta property="og:image" content="{{ root }}logo_ogp_3.png">
-    <meta property="og:locale" content="ja_JP">
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="@CamphorKyoto">
-    <meta name="twitter:title" content="{{ title }}">
-    <meta name="twitter:description" content="{{ description }}">
-    <meta name="twitter:image" content="{{ root }}logo_twitter_2.png">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link rel="amphtml" href="{{ root }}amp.html">
-    <style>
-      {% include "base.css" %}
+    <head prefix="og: http://ogp.me/ns#">
+        <meta charset="utf-8">
+        <title>{{ title }}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="keywords" content="Advent,Calendar,アドベントカレンダー,CAMPHOR-,京都,学生,IT">
+        <meta name="description" content="京都の学生コミュニティ CAMPHOR- の Advent Calendar 特設ページです。様々な記事を毎日追加していきます。">
+        <meta property="og:type" content="website">
+        <meta property="og:title" content="{{ title }}">
+        <meta property="og:site_name" content="{{ title }}">
+        <meta property="og:description" content="{{ description }}">
+        <meta property="og:url" content="{{ root }}">
+        <meta property="og:image" content="{{ root }}logo_ogp_3.png">
+        <meta property="og:locale" content="ja_JP">
+        <meta name="twitter:card" content="summary">
+        <meta name="twitter:site" content="@CamphorKyoto">
+        <meta name="twitter:title" content="{{ title }}">
+        <meta name="twitter:description" content="{{ description }}">
+        <meta name="twitter:image" content="{{ root }}logo_twitter_2.png">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+        crossorigin="anonymous">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
+        crossorigin="anonymous">
+        <link rel="amphtml" href="{{ root }}amp.html">
+        <style>
+            {% include "base.css" %}
 
-      .jumbotron h1 {
-        font-size: 48px;
-      }
+            .jumbotron h1 {
+                font-size: 48px;
+            }
 
-      @media (max-width: 768px) {
-        .jumbotron h1 {
-          font-size: 32px;
-        }
-      }
+            @media (max-width: 768px) {
+                .jumbotron h1 {
+                    font-size: 32px;
+                }
+            }
 
-      @media (max-width: 320px) {
-        .jumbotron h1 {
-          font-size: 25px;
-        }
-      }
+            @media (max-width: 320px) {
+                .jumbotron h1 {
+                    font-size: 25px;
+                }
+            }
 
-      .social-buttons {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-      }
+            .social-buttons {
+                position: fixed;
+                bottom: 20px;
+                right: 20px;
+            }
 
-      .social-buttons a {
-        display: inline-block;
-        margin: 0 4px;
-        border-radius: 25px;
-        border-width: 0;
-        padding: 0;
-        width: 50px;
-        height: 50px;
-        line-height: 50px;
-        font-size: 25px;
-        color: white;
-      }
+            .social-buttons a {
+                display: inline-block;
+                margin: 0 4px;
+                border-radius: 25px;
+                border-width: 0;
+                padding: 0;
+                width: 50px;
+                height: 50px;
+                line-height: 50px;
+                font-size: 25px;
+                color: white;
+            }
 
-      .social-buttons a:focus,
-      .social-buttons a:hover {
-        color: white;
-      }
+            .social-buttons a:focus,
+            .social-buttons a:hover {
+                color: white;
+            }
 
-      .social-buttons a.twitter {
-        background-color: #55acee;
-      }
+            .social-buttons a.twitter {
+                background-color: #55acee;
+            }
 
-      .social-buttons a.twitter:focus,
-      .social-buttons a.twitter:hover {
-        background-color: #4790c7;
-      }
+            .social-buttons a.twitter:focus, 
+            .social-buttons a.twitter:hover {
+                background-color: #4790c7;
+            }
 
-      .social-buttons a.facebook {
-        background-color: #3b5998;
-      }
+            .social-buttons a.facebook {
+                background-color: #3b5998;
+            }
 
-      .social-buttons a.facebook:focus,
-      .social-buttons a.facebook:hover {
-        background-color: #2D4373;
-      }
-    </style>
-  </head>
-  <body>
-    <nav class="navbar navbar-default">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="#">CAMPHOR- Advent Calendar</a>
-        </div>
-        <div class="collapse navbar-collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-            <li><a href="https://blog.camph.net" target="_blank">Blog</a></li>
-            <li><a href="https://tech.camph.net" target="_blank">Tech Blog</a></li>
-            <li><a href="https://twitter.com/CamphorKyoto" target="_blank">Twitter</a></li>
-            <li><a href="https://www.facebook.com/Camphorcamphor/" target="_blank">Facebook</a></li>
-            <li><a href="https://camph.net" target="_blank">Website</a></li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-    <div class="jumbotron">
-      <div class="container">
-        <div class="row">
-          <div class="col-sm-12 col-md-offset-2 col-md-8 text-center">
-            <h1>
-              <img class="img-responsive" src="./header.svg" alt="CAMPHOR- Advent Calendar">
+            .social-buttons a.facebook:focus, 
+            .social-buttons a.facebook:hover {
+                background-color: #2D4373;
+            }
+        </style>
+    </head>
+    <body>
+        <nav class="navbar navbar-light bg-light navbar-expand-md">
+                <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbar-collapse"> 
+                  <span class="sr-only">Toggle navigation</span>
+                  &#x2630;
+                </button>
+                <a class="navbar-brand" href="#">CAMPHOR- Advent Calendar</a>
+                <div class="collapse navbar-collapse" id="navbar-collapse">
+                    <ul class="nav navbar-nav ml-auto">
+                        <li class="nav-item"><a href="https://blog.camph.net" target="_blank" class="nav-link">Blog</a></li>
+                        <li class="nav-item"><a href="https://tech.camph.net" target="_blank" class="nav-link">Tech Blog</a></li>
+                        <li class="nav-item"><a href="https://twitter.com/CamphorKyoto" target="_blank" class="nav-link">Twitter</a></li>
+                        <li class="nav-item"><a href="https://www.facebook.com/Camphorcamphor/" target="_blank" class="nav-link">Facebook</a></li>
+                        <li class="nav-item"><a href="https://camph.net" target="_blank" class="nav-link">Website</a></li>
+                    </ul>
+                </div>
+        </nav>
+        <div class="jumbotron">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12 offset-md-2 col-lg-8 text-center">
+                         <h1>
+              <img class="img-fluid" src="./header.svg" alt="CAMPHOR- Advent Calendar">
             </h1>
             <p class="lead">
               CAMPHOR- のメンバーとOB・OGが様々なトピックをお届けします!
+            </p>     
+              </div>
+            </div>
+        </div>
+        </div>
+        <div class="container">
+            <div class="row">
+              {% for year, entries in entries_for_years.items() %}
+                <div class="col-12">
+                     <h2>{{ year }}</h2>
+                    <div class="table-responsive">
+                        <table class="table table-striped schedule">
+                            <tr><th>日</th><th>担当</th><th>タイトル</th><th class="text-right">はてブ</th></tr>
+                            {% for entry in entries %}                            
+                            <tr>
+                                <td>{{ entry.date.month }}/{{ entry.date.day }}</td>
+                                <td>
+                                  {% if entry.author %}
+                                    {% if entry.author_url %}
+                                      <a href="{{ entry.author_url }}" target="_blank">{{ entry.author }}</a>
+                                      {% else %} 
+                                        {{ entry.author }}
+                                      {% endif %} 
+                                    {% else %}
+                                     未定 
+                                    {% endif %}
+                                  </td>
+                                <td>
+                                  {% if entry.title %} 
+                                    {% if entry.url %} 
+                                    <a href="{{ entry.url }}" target="_blank">{{ entry.title }}</a>
+                                    {% else %}
+                                      {{ entry.title }}
+                                      {% endif %} 
+                                      {% else %}
+                                      未定
+                                        {% endif %}
+                                      </td>
+                                <td class="text-right">
+                                  {% if entry.url %}
+                                   <a href="http://b.hatena.ne.jp/entry/{{ entry.url }}" class="hateb-link" data-url="{{ entry.url }}" target="_blank">Loading</a>
+                                    {% else %} 
+                                    - 
+                                    {% endif %}
+                                  </td>
+                            </tr>
+                            {% endfor %}
+                          </table>
+                    </div>
+                </div>
+                {% endfor %}
+              </div>
+        </div>
+        <footer class="text-center">
+            <hr>
+            <p>
+              Copyright &copy; 2014-2018, CAMPHOR-.
             </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="container">
-      <div class="row">
-        {% for year, entries in entries_for_years.items() %}
-        <div class="col-xs-12">
-          <h2>{{ year }}</h2>
-          <div class="table-responsive">
-            <table class="table table-striped schedule">
-              <tr><th>日</th><th>担当</th><th>タイトル</th><th class="text-right">はてブ</th></tr>
-              {% for entry in entries %}
-              <tr>
-                <td>{{ entry.date.month }}/{{ entry.date.day }}</td>
-                <td>
-                  {% if entry.author %}
-                    {% if entry.author_url %}
-                      <a href="{{ entry.author_url }}" target="_blank">{{ entry.author }}</a>
-                    {% else %}
-                      {{ entry.author }}
-                    {% endif %}
-                  {% else %}
-                    未定
-                  {% endif %}
-                </td>
-                <td>
-                  {% if entry.title %}
-                    {% if entry.url %}
-                    <a href="{{ entry.url }}" target="_blank">{{ entry.title }}</a>
-                    {% else %}
-                      {{ entry.title }}
-                    {% endif %}
-                  {% else %}
-                    未定
-                  {% endif %}
-                </td>
-                <td class="text-right">
-                  {% if entry.url %}
-                    <a href="http://b.hatena.ne.jp/entry/{{ entry.url }}" class="hateb-link" data-url="{{ entry.url }}" target="_blank">Loading</a>
-                  {% else %}
-                    -
-                  {% endif %}
-                </td>
-              </tr>
-              {% endfor %}
-            </table>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-    <footer class="text-center">
-      <hr>
-      <p>
-        Copyright &copy; 2014-2018, CAMPHOR-.
-      </p>
-    </footer>
-    <div class="social-buttons">
-      <a class="btn twitter" href="https://twitter.com/intent/tweet?text=CAMPHOR%2D%20Advent%20Calendar&url=https%3A%2F%2Fadvent.camph.net%2F&via=CamphorKyoto&related=CamphorKyoto" target="_blank">
+        </footer>
+        <div class="social-buttons">
+          <a class="btn twitter" href="https://twitter.com/intent/tweet?text=CAMPHOR%2D%20Advent%20Calendar&url=https%3A%2F%2Fadvent.camph.net%2F&via=CamphorKyoto&related=CamphorKyoto" target="_blank">
         <i class="fa fa-twitter" aria-hidden="true"></i>
       </a>
-      <a class="btn facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fadvent.camph.net%2F" target="_blank">
+ <a class="btn facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fadvent.camph.net%2F" target="_blank">
         <i class="fa fa-facebook" aria-hidden="true"></i>
       </a>
-    </div>
-    <script type="application/ld+json">
-      {
-        "@context": "http://schema.org",
-        "@type": "WebSite",
-        "name": "CAMPHOR- Advent Calendar",
-        "url": "https://advent.camph.net/"
-      }
-    </script>
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <script src="./index.js"></script>
-    {% if not debug %}
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-36244002-7', 'auto');
-      ga('send', 'pageview');
-    </script>
-    {% endif %}
-  </body>
+        </div>
+        <script type="application/ld+json">
+          {
+            "@context": "http://schema.org",
+            "@type": "WebSite",
+            "name": "CAMPHOR- Advent Calendar",
+            "url": "https://advent.camph.net/"
+          }
+        </script>
+        <script src="https://code.jquery.com/jquery-3.3.1.min.js"  crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script src="./index.js"></script>
+        {% if not debug %}
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+            ga('create', 'UA-36244002-7', 'auto');
+            ga('send', 'pageview');
+          </script>
+         {% endif %}
+        </body>
 </html>


### PR DESCRIPTION
## What

- bootstrapをメジャーバージョンアップし、4.x系にする
- UI崩れに対応するために自分(@p1ass)の記事のタイトルを変更
- フォーマッタを実行

## Memo

commitごとにレビューしたほうがわかりやすいです。

## Screenshot
 

<img src="https://user-images.githubusercontent.com/30015728/67946031-bad3ac00-fc23-11e9-912a-ef9b47b7f0aa.png" width="300px">


![FireShot Capture 022 - CAMPHOR- Advent Calendar - localhost](https://user-images.githubusercontent.com/30015728/67946003-a8597280-fc23-11e9-9cf5-68cf6d90ff7b.png)
