### PR TITLE
Fix hateb count when hateblo.jp

### DIFF
--- a/output/index.js
+++ b/output/index.js
@@ -6,6 +6,11 @@ $(document).ready(function () {
     return url.replace(/^https?:\/\//, "");
   }
 
+  function isHatebloDomain(url){
+    var u = new URL(url);
+    return u.host.endsWith("hateblo.jp");
+  }
+
   var urlTo$ = {};
   $(".hateb-link")
     .each(function (i, item) {
@@ -40,7 +45,7 @@ $(document).ready(function () {
         var $item = urlTo$[urlWithoutProtocol];
         var previousCount = $item.data("count");
         previousCount = previousCount ? previousCount : 0;
-        var count = urlCount[1] + previousCount;
+        var count = isHatebloDomain($item.data("url"))? urlCount[1] : urlCount[1] + previousCount;
         var suffix = count === 1 ? "User" : "Users";
         $item.data("count", count);
         $item.html(count + " " + suffix);

--- a/output/index.js
+++ b/output/index.js
@@ -45,16 +45,16 @@ $(document).ready(function () {
         var url = urlCount[0];
         var urlWithoutProtocol = getUrlWithoutProtocol(url);
         var $item = urlTo$[urlWithoutProtocol];
-        var previousCount = $item.data("count");
-        previousCount = previousCount ? previousCount : 0;
+        var previousCount = $item.data("count") ? $item.data("count") : 0 ;
 
-        var count =  urlCount[1] + previousCount
-        notAddingCountDomains.some(function(domain){
-          if (matchDomain($item.data("url"),domain)){
-            count -= previousCount;
-            return true;
-          }
+        var count = urlCount[1];
+        var isMatched = notAddingCountDomains.some(function(domain){
+          return matchDomain($item.data("url"), domain)
         });
+        if (!isMatched) {
+          count += previousCount;
+        }
+
         var suffix = count === 1 ? "User" : "Users";
         $item.data("count", count);
         $item.html(count + " " + suffix);

--- a/output/index.js
+++ b/output/index.js
@@ -6,9 +6,9 @@ $(document).ready(function () {
     return url.replace(/^https?:\/\//, "");
   }
 
-  function isHatebloDomain(url){
+  function matchDomain(url,domain){
     var u = new URL(url);
-    return u.host.endsWith("hateblo.jp");
+    return u.host.endsWith(domain);
   }
 
   var urlTo$ = {};
@@ -22,6 +22,8 @@ $(document).ready(function () {
 
   var urls = Object.keys(urlTo$);
   var PER_PAGE = 50 / 2;  // Every request contains both HTTP and HTTPS urls
+
+  var notAddingCountDomains = ["hateblo.jp"]
 
   for (var page = 0; page < Math.ceil(urls.length / PER_PAGE); page++) {
     var urlsWithoutProtocol = [];
@@ -45,7 +47,14 @@ $(document).ready(function () {
         var $item = urlTo$[urlWithoutProtocol];
         var previousCount = $item.data("count");
         previousCount = previousCount ? previousCount : 0;
-        var count = isHatebloDomain($item.data("url"))? urlCount[1] : urlCount[1] + previousCount;
+
+        var count =  urlCount[1] + previousCount
+        notAddingCountDomains.some(function(domain){
+          if (matchDomain($item.data("url"),domain)){
+            count -= previousCount;
+            return true;
+          }
+        });
         var suffix = count === 1 ? "User" : "Users";
         $item.data("count", count);
         $item.html(count + " " + suffix);


### PR DESCRIPTION
## Why

genyaさんの記事のはてブカウントがおかしい (正しくは51)

<img width="1114" alt="スクリーンショット 2019-11-30 16 03 03" src="https://user-images.githubusercontent.com/30015728/69897158-fda3b380-138a-11ea-9b6e-307c43480cf4.png">

HTTPとHTTPSの両方のはてブのAPIを叩いているが、 `hateblo.jp` の時は 両方とも同じ値を返してしまって、足されて2倍の値になっていた。

## What

HTTPとHTTPSで同じ値を返すドメインの時は、カウントを足さないという処理を追加する
