### PR TITLE
Change tweet message template

### DIFF
--- a/gen_tweet.py
+++ b/gen_tweet.py
@@ -31,10 +31,10 @@ def get_author(name):
 
 def build_tweet(entry, author):
     tweet = (
-                f"CAMPHOR- Advent Calendar {today.year} の本日の記事は、"
+                f"CAMPHOR- Advent Calendar {today.year} "
+                f"(https://advent.camph.net/) の本日の記事は、"
                 f"{author.name} ({author.url}) による 「{entry.title}」 です。\n"
-                f"{entry.url}\n\n"
-                "https://advent.camph.net/"
+                f"{entry.url}\n"
             )
     return tweet
 

--- a/gen_tweet.py
+++ b/gen_tweet.py
@@ -34,7 +34,7 @@ def build_tweet(entry, author):
                 f"CAMPHOR- Advent Calendar {today.year} "
                 f"(https://advent.camph.net/) の本日の記事は、"
                 f"{author.name} ({author.url}) による 「{entry.title}」 です。\n"
-                f"{entry.url}\n"
+                f"{entry.url}"
             )
     return tweet
 


### PR DESCRIPTION
## Why

現状のフォーマットではOGPが advent.camph.net の方になっている。
多くの場合は特設サイトではなく、記事を見たいと思っているはずなので、UXが悪いと考えられる。


<img src="https://user-images.githubusercontent.com/30015728/69917313-d262b680-14a7-11ea-80e2-13391c1c4b35.jpg" width="250px">

## What

文章のテンプレートを変更して、記事のOGPが表示されるようにする。

<img src="https://user-images.githubusercontent.com/30015728/69917243-389b0980-14a7-11ea-9e9f-77766f0fb5e3.jpg" width="250px">
