### PR TITLE
Use latest Python 3.8 everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.8
 
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run:
           command: |
             apt update
-            apt install -y openjdk-8-jre-headless unzip
+            apt install -y openjdk-11-jre-headless unzip
 
       - run:
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3-slim
+FROM python:3.8-slim
 
 RUN mkdir -p /app/
 WORKDIR /app

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,2 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8


### PR DESCRIPTION
- Use latest Python 3.8 Docker image
- Use Python 3.8 on CircleCI
- Use Python 3.8 when typechecking with mypy