### PR TITLE
Fix broken layout of image with specific screen width

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -126,7 +126,7 @@
     <div class="jumbotron">
       <div class="container">
         <div class="row">
-          <div class="col-md-12 offset-md-2 col-lg-8 text-center">
+          <div class="col-md-12 offset-lg-2 col-lg-8 text-center">
             <h1>
               <img class="img-fluid" src="./header.svg" alt="CAMPHOR- Advent Calendar">
             </h1>


### PR DESCRIPTION
Example of the bug: [![Image from Gyazo](https://i.gyazo.com/2545ae14ae9a6f1f63ebc6380abbb2cf.png)](https://gyazo.com/2545ae14ae9a6f1f63ebc6380abbb2cf)