### PR TITLE
CDの改善

### DIFF
--- a/.github/workflows/build-and-sync.yml
+++ b/.github/workflows/build-and-sync.yml
@@ -2,7 +2,7 @@ name: Build and Sync
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/build-and-sync.yml
+++ b/.github/workflows/build-and-sync.yml
@@ -1,10 +1,8 @@
-name: Build and Deploy
+name: Build and Sync
 
 on:
   push:
     branches: [master]
-  schedule:
-    - cron: "0 15 * 11,12 *" # 00:00 JST in November and December (15:00 UTC)
 
 jobs:
   build:
@@ -30,10 +28,10 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: failure()
-  deploy:
-    name: Deploy to konoe
-    runs-on: ubuntu-latest
+  sync:
+    name: Sync
     needs: build
+    runs-on: ubuntu-latest
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
@@ -41,10 +39,6 @@ jobs:
           key: ${{ secrets.KONOE_SSH_KEY }}
           name: id_rsa
           known_hosts: ${{ secrets.KONOE_KNOWN_HOSTS }}
-      - name: Setup docker context
-        run: |
-          docker context create --default-stack-orchestrator=swarm --docker "host=ssh://${{ secrets.KONOE_SSH_USERNAME }}@${{ secrets.KONOE_SSH_HOST }}:${{ secrets.KONOE_SSH_PORT }}" konoe
-          docker context use konoe
       - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
@@ -53,10 +47,12 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
       - name: Check out
         uses: actions/checkout@v2
-      - name: Deploy advent
+      - name: Build advent
         run: |
-          docker-compose --context konoe -f docker-compose.prod.yml pull
-          docker-compose --context konoe -f docker-compose.prod.yml up --force-recreate
+          docker-compose -f docker-compose.prod.yml pull
+          docker-compose -f docker-compose.prod.yml up --force-recreate
+      - name: rsync output
+        run: rsync -r $PWD/output -e "ssh -p ${{ secrets.KONOE_SSH_PORT }}" ${{ secrets.KONOE_SSH_USERNAME }}@${{ secrets.KONOE_SSH_HOST }}:/home/deploy/advent
       - name: Notify to Slack
         uses: craftech-io/slack-action@v1
         with:

--- a/.github/workflows/build-and-sync.yml
+++ b/.github/workflows/build-and-sync.yml
@@ -2,7 +2,7 @@ name: Build and Sync
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,7 @@
 name: Sync
 
 on:
+  push:
   schedule:
     - cron: "0 15 * 11,12 *" # 00:00 JST in November and December (15:00 UTC)
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,7 +9,6 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,37 @@
+name: Sync
+
+on:
+  schedule:
+    - cron: "0 15 * 11,12 *" # 00:00 JST in November and December (15:00 UTC)
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.KONOE_SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KONOE_KNOWN_HOSTS }}
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.camph.net
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Build advent
+        run: |
+          docker-compose -f docker-compose.prod.yml pull
+          docker-compose -f docker-compose.prod.yml up --force-recreate
+      - name: rsync output
+        run: rsync -r $PWD/output -e "ssh -p ${{ secrets.KONOE_SSH_PORT }}" ${{ secrets.KONOE_SSH_USERNAME }}@${{ secrets.KONOE_SSH_HOST }}:/home/deploy/advent
+      - name: Notify to Slack
+        uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,6 @@
 name: Sync
 
 on:
-  push:
   schedule:
     - cron: "0 15 * 11,12 *" # 00:00 JST in November and December (15:00 UTC)
 

--- a/data/entries.yml
+++ b/data/entries.yml
@@ -845,7 +845,7 @@
     - クラウドファンディング
     - Web
 
-- date: 2018-12-10
+- date: 2021-12-10
   author: aratasato
   title: 「Webサービスを作りたい！」と思ってから実際に作るまで5年かかった
   url: https://ataran.hatenablog.com/entry/five_years_to_web_app

--- a/data/entries.yml
+++ b/data/entries.yml
@@ -845,7 +845,7 @@
     - クラウドファンディング
     - Web
 
-- date: 2021-12-10
+- date: 2018-12-10
   author: aratasato
   title: 「Webサービスを作りたい！」と思ってから実際に作るまで5年かかった
   url: https://ataran.hatenablog.com/entry/five_years_to_web_app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,8 +2,9 @@ version: "3.3"
 
 services:
   advent:
+    build: .
     image: registry.camph.net/advent:latest
     network_mode: none
     volumes:
-      - /home/deploy/advent/data:/app/data:ro
-      - /home/deploy/advent/output:/app/output
+      - ./data:/app/data:ro
+      - ./output:/app/output

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,6 @@ version: "3.3"
 
 services:
   advent:
-    build: .
     image: registry.camph.net/advent:latest
     network_mode: none
     volumes:


### PR DESCRIPTION
- アドカレ期間中に毎日イメージをビルドしない closes #118 
- `/output`をrsyncでkonoeに送る closes #119 

[Build and Syncのログ](https://github.com/camphor-/advent/actions/runs/452451676)
[Syncのログ](https://github.com/camphor-/advent/actions/runs/452444218)