### PR TITLE
Upgrade to Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: python:3.8
+      - image: python:3.9
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 RUN mkdir -p /app/
 WORKDIR /app

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,2 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,11 +6,11 @@
 #
 attrs==20.3.0
     # via pytest
-flake8==3.9.0
+flake8==3.9.1
     # via -r requirements.test.in
-freezegun==1.0.0
+freezegun==1.1.0
     # via pytest-freezegun
-importlib-metadata==3.10.0
+importlib-metadata==3.10.1
     # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
@@ -18,17 +18,17 @@ mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
     # via mypy
-mypy==0.790
+mypy==0.812
     # via -r requirements.test.in
-packaging==20.7
+packaging==20.9
     # via pytest
 pluggy==0.13.1
     # via pytest
-py==1.9.0
+py==1.10.0
     # via pytest
 pycodestyle==2.7.0
     # via flake8
-pyflakes==2.3.0
+pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
@@ -50,7 +50,7 @@ six==1.15.0
     # via python-dateutil
 toml==0.10.2
     # via pytest
-typed-ast==1.4.2
+typed-ast==1.4.3
     # via
     #   -r requirements.test.in
     #   mypy


### PR DESCRIPTION
Upgrading Python in the Docker image and one on CircleCI to 3.9. To support the runtime upgrade, upgrade dependencies as well. Closes #129 #136 