### PR TITLE
Use zoneinfo stdlib instead of pytz

### DIFF
--- a/advent/data.py
+++ b/advent/data.py
@@ -2,13 +2,13 @@ from datetime import date, datetime
 from operator import attrgetter
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 import yaml
 
 from advent.models import Author, Entry
 
-TIMEZONE = pytz.timezone("Asia/Tokyo")
+TIMEZONE = ZoneInfo("Asia/Tokyo")
 
 
 def load_authors(authors_file: Path) -> Dict[str, Author]:

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,2 @@
 Jinja2
-pytz
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,5 @@ jinja2==2.11.3
     # via -r requirements.in
 markupsafe==1.1.1
     # via jinja2
-pytz==2021.1
-    # via -r requirements.in
 pyyaml==5.4.1
     # via -r requirements.in


### PR DESCRIPTION
Note that we need to have tzdata installed on systems. Our Docker image already includes the module.

Closes #96.