### PR TITLE
data, outputディレクトリをコンテナイメージ内に入れるように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN mkdir -p /app/
 WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
+COPY ./data /app/data
+COPY ./output /app/output
 
 RUN pip install -r requirements.txt \
         && rm -rf /root/.cache

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,3 @@ services:
   advent:
     image: registry.camph.net/advent:latest
     network_mode: none
-    volumes:
-      - ./data:/app/data:ro
-      - ./output:/app/output


### PR DESCRIPTION
元々ボリュームで後挿しにしていたdataディレクトリとoutputディレクトリについて、DockerfileでCOPYすることでコンテナイメージ内に入れるように変更